### PR TITLE
Move Dockerfile to top of repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,13 +62,13 @@ RUN git clone https://github.com/shenlab-sinai/ngsplot.git && cd ngsplot && git 
 
 RUN git clone https://github.com/alexdobin/STAR.git && cd STAR && git checkout tags/2.5.2b && cp bin/Linux_x86_64_static/* /usr/local/bin
 
-COPY resources/modulefiles/ /etc/modulefiles/
+COPY docker/resources/modulefiles/ /etc/modulefiles/
 
-COPY resources/rsetup.R . 
+COPY docker/resources/rsetup.R . 
 
 RUN source /etc/profile.d/modules.sh && module load R && Rscript rsetup.R
 
-COPY resources/environment.yml .
+COPY docker/resources/environment.yml .
 
 RUN mkdir -p /software/anaconda2 && curl -L -O https://repo.continuum.io/archive/Anaconda2-2.4.1-Linux-x86_64.sh && \
     chmod 755 Anaconda2-2.4.1-Linux-x86_64.sh && bash Anaconda2-2.4.1-Linux-x86_64.sh -p /software/anaconda2 -f -b && \
@@ -79,12 +79,12 @@ RUN source /etc/profile.d/modules.sh && module load python/anaconda && conda ins
 
 RUN rm -rf *
 
-RUN mkdir -p /projects/p20742/tools
+RUN mkdir -p /projects/p20742/tools/bin
 
-WORKDIR /projects/p20742/tools
+WORKDIR /projects/p20742/tools/bin
 
 # copy all R and perl scripts into image
-COPY *.R *.pl ./
+COPY bin/* ./
 
 # install the stuff that the pipeline runs directly inside /projects/p20742
 RUN curl -O http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bedToBigBed && chmod 755 bedToBigBed
@@ -96,7 +96,7 @@ RUN mkdir GATK_v3.6 && cd GATK_v3.6 && \
 	bunzip2 GenomeAnalysisTK-3.6-0-g89b7209.tar.bz2 && tar xvf GenomeAnalysisTK-3.6-0-g89b7209.tar && \
 	mv resources/* .
 
-COPY resources/SICER_V1.1.tgz .
+COPY docker/resources/SICER_V1.1.tgz .
 
 RUN tar xvfz SICER_V1.1.tgz && cd SICER_V1.1/SICER && \
 	find . -name '*.sh' -print | xargs sed -i 's|/home/data/SICER1.1|/projects/p20742/tools/SICER_V1.1|g'
@@ -111,8 +111,12 @@ RUN git clone https://github.com/deweylab/RSEM.git RSEM-1.3.0 && cd RSEM-1.3.0 &
 # have to symlink perl executable in order for buildPipelineScripts.pl to run
 RUN mkdir -p /software/activeperl/5.16/bin && ln -s /usr/bin/perl /software/activeperl/5.16/bin/perl
 
-COPY resources/wrapper.sh .
+WORKDIR /projects/p20742/tools
+
+COPY docker/resources/wrapper.sh .
 
 RUN chmod 755 wrapper.sh
+
+RUN ln -s bin/buildPipelineScripts.pl buildPipelineScripts.pl
 
 ENTRYPOINT ["/projects/p20742/tools/wrapper.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,9 @@ RUN git clone https://github.com/taoliu/MACS.git MACS-1.4.2 && cd MACS-1.4.2 && 
 RUN git clone https://github.com/deweylab/RSEM.git RSEM-1.3.0 && cd RSEM-1.3.0 && git checkout tags/v1.3.0 && make && \
     source /etc/profile.d/modules.sh && module load R && make ebseq
 
+RUN curl -O https://www.bioinformatics.babraham.ac.uk/projects/fastq_screen/fastq_screen_v0.11.4.tar.gz && tar -zxf fastq_screen_v0.11.4.tar.gz
+
+COPY docker/resources/fastq_screen.allRefs.conf fastq_screen_v0.11.4/
 # have to symlink perl executable in order for buildPipelineScripts.pl to run
 RUN mkdir -p /software/activeperl/5.16/bin && ln -s /usr/bin/perl /software/activeperl/5.16/bin/perl
 

--- a/docker/resources/fastq_screen.allRefs.conf
+++ b/docker/resources/fastq_screen.allRefs.conf
@@ -1,0 +1,63 @@
+# This is an example configuration file for FastQ Screen
+
+############################
+## Bowtie, Bowtie 2 or BWA #
+############################
+
+# Make sure modules are loaded properly on quest, so executables are in path.
+
+############
+## Threads #
+############
+## Genome aligners can be made to run across multiple CPU cores to speed up 
+## searches.  Set this value to the number of cores you want for mapping reads.
+
+# This will typically be set when fastq-screen is called; this is only a backup value.
+
+THREADS		4
+
+
+##############
+## DATABASES #
+##############
+## This section enables you to configure multiple genomes databases (aligner index 
+## files) to search against in your screen.  For each genome you need to provide a 
+## database name (which can't contain spaces) and the location of the aligner index 
+## files.
+##
+## The path to the index files SHOULD INCLUDE THE BASENAME of the index, e.g:
+## /data/public/Genomes/Human_Bowtie/GRCh37/Homo_sapiens.GRCh37
+## Thus, the index files (Homo_sapiens.GRCh37.1.bt2, Homo_sapiens.GRCh37.2.bt2, etc.) 
+## are found in a folder named 'GRCh37'.
+##
+## If, for example, the Bowtie, Bowtie2 and BWA indices of a given genome reside in 
+## the SAME FOLDER, a SINLGE path may be provided to ALL the of indices.  The index 
+## used will be the one compatible with the chosen aligner (as specified using the 
+## --aligner flag).  
+##
+
+
+## Human
+DATABASE human_hg38 /projects/p20742/anno/bowtie_indexes/hg38
+DATABASE human_hg19 /projects/p20742/anno/bowtie_indexes/hg19
+DATABASE human_rRNA /projects/p20742/anno/bowtie_indexes/humanRRNA
+## Mouse
+DATABASE mouse_mm10 /projects/p20742/anno/bowtie_indexes/mm10
+DATABASE mouse_mm9 /projects/p20742/anno/bowtie_indexes/mm9
+DATABASE mouse_rRNA /projects/p20742/anno/bowtie_indexes/mouseRRNA
+## Rat
+DATABASE rat_rn6 /projects/p20742/anno/bowtie_indexes/rn6
+DATABASE rat_rRNA /projects/p20742/anno/bowtie_indexes/ratRRNA
+## Fruitfly
+DATABASE fly_dm3 /projects/p20742/anno/bowtie_indexes/dm3
+## Yeast
+DATABASE yeast_sacCer3 /projects/p20742/anno/bowtie_indexes/sacCer3
+## Mhy
+DATABASE M_hyorhinis /projects/p20742/anno/bowtie_indexes/mp_hyo
+## Mho
+DATABASE M_hominis /projects/p20742/anno/bowtie_indexes/mp_hom
+## Mfe
+DATABASE M_fermentans /projects/p20742/anno/bowtie_indexes/mp_fer
+## Ala
+DATABASE A_laidlawii /projects/p20742/anno/bowtie_indexes/ap_lai
+


### PR DESCRIPTION
In order for the docker image to be built from this Dockerfile without having to write a complex build system, the Dockerfile must be at the "top" level of the repository. This PR moves the Dockerfile up to the top and changes the paths within the Dockerfile to reflect the new project layout.

Also the fastq_screen tool is added (along with the configuration file as it currently exists on Quest).